### PR TITLE
feat(frontend): fetch tag from branch not develop

### DIFF
--- a/.github/workflows/frontend-build-and-publish-apps.yml
+++ b/.github/workflows/frontend-build-and-publish-apps.yml
@@ -73,6 +73,15 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3.0.0
+        if: github.event_name == 'pull_request'
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.github-token }}
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout
+        uses: actions/checkout@v3.0.0
+        if: github.event_name != 'pull_request'
         with:
           fetch-depth: 0
           token: ${{ secrets.github-token }}

--- a/.github/workflows/frontend-build-and-publish-apps.yml
+++ b/.github/workflows/frontend-build-and-publish-apps.yml
@@ -71,6 +71,9 @@ jobs:
           echo dotnet cli version':' $DOTNET_CLI_V
           git --version
 
+          TEST=${{github.event.pull_request.head.sha}}
+          echo test':' $TEST
+
       - name: Checkout
         uses: actions/checkout@v3.0.0
         if: github.event_name == 'pull_request'

--- a/.github/workflows/frontend-build-and-publish-apps.yml
+++ b/.github/workflows/frontend-build-and-publish-apps.yml
@@ -71,9 +71,6 @@ jobs:
           echo dotnet cli version':' $DOTNET_CLI_V
           git --version
 
-          TEST=${{github.event.pull_request.head.sha}}
-          echo test':' $TEST
-
       - name: Checkout
         uses: actions/checkout@v3.0.0
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This change is introduced to get correct tag from feature branch, not merge commit (which is actually latest develop branch). The issue was that PR event checks out the merge commit, not PR itself.

We need to be aware that with this change the build would not run against the merge, but against the PR itself, which isn't really telling us if it will build on merge.

https://rivertechplc.slack.com/archives/G010QGNM754/p1651056500568079