### PR TITLE
fix(node libs): escape commit msg backticks

### DIFF
--- a/.github/workflows/node-libs.yml
+++ b/.github/workflows/node-libs.yml
@@ -125,7 +125,7 @@ jobs:
             COMMIT_MSG=$(git log -1 --pretty=%B HEAD^2)
           else
             BRANCH_NAME=$GITHUB_REF_NAME
-            COMMIT_MSG="${{github.event.head_commit.message}}"
+            COMMIT_MSG='${{github.event.head_commit.message}}'
           fi
           echo "::notice ::Branch name: $BRANCH_NAME :: Commit message: $COMMIT_MSG"
           echo "branch-name=$BRANCH_NAME" >> $GITHUB_OUTPUT


### PR DESCRIPTION
fix for: https://github.com/River-iGaming/odin.ngx.schematics/actions/runs/5598320451/job/15164263735
due to commit msg being ```feat(dotnet entity store): entity meta changes `kind` (align with ng entity store) (#28)```