### PR TITLE
feat(check version): job is now being called from app directly

### DIFF
--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -1,23 +1,9 @@
 name: Check Node package.json Version Bump
-on:
-  workflow_call:
-    inputs:
-      should-bump-version:
-        description: list of branches that require version bump
-        required: false
-        type: string
 jobs:
   check-version-bump:
     runs-on: ubuntu-latest
-    if: contains(inputs.should-bump-version, github.base_ref)
 
     steps:
-      - name: echo stuff
-        run: |
-          echo should bump version ${{ inputs.should-bump-version }}
-          echo baseref ${{ github.base_ref }}
-          echo ${{contains(inputs.should-bump-version, github.base_ref)}}
-
       - name: Checkout current code
         uses: actions/checkout@v4
 

--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -8,6 +8,9 @@ jobs:
     steps:
       - name: Checkout current code
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: package.json
+          sparse-checkout-cone-mode: false
 
       - name: Get the current version
         id: current
@@ -17,6 +20,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
+          sparse-checkout: package.json
+          sparse-checkout-cone-mode: false
 
       - name: Get the base branch version
         id: base

--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -17,6 +17,13 @@ jobs:
         run: |
           echo should bump version ${{ inputs.should-bump-version }}
           echo baseref ${{ github.base_ref }}
+          echo ${{contains(inputs.should-bump-version, github.base_ref)}}
+
+      - name: echo stuff
+        run: |
+          echo should bump version ${ inputs.should-bump-version }
+          echo baseref ${ github.base_ref }
+          echo ${contains(inputs.should-bump-version, github.base_ref)}
 
       - name: Checkout current code
         uses: actions/checkout@v4

--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -13,6 +13,11 @@ jobs:
     if: contains(inputs.should-bump-version, github.base_ref)
 
     steps:
+      - name: echo stuff
+        run: |
+          echo should bump version ${{ inputs.should-bump-version }}
+          echo baseref ${{ github.base_ref }}
+
       - name: Checkout current code
         uses: actions/checkout@v4
 

--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -27,10 +27,6 @@ jobs:
           current_version="${{ steps.current.outputs.version }}"
           base_version="${{ steps.base.outputs.version }}"
 
-          echo current version: "$current_version"
-          echo base version: "$base_version"
-          echo base_ref "$github.base_ref"
-
           if [[ "$(printf '%s\n' "$current_version" "$base_version" | sort -V | tail -n 1)" == "$base_version" ]]; then
             echo "package.json version is not greater than the base branch. Please bump the version."
             exit 1

--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -1,4 +1,6 @@
 name: Check Node package.json Version Bump
+on:
+  workflow_call
 jobs:
   check-version-bump:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -1,6 +1,6 @@
 name: Check Node package.json Version Bump
 on:
-  workflow_call
+  workflow_call:
 jobs:
   check-version-bump:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -1,24 +1,9 @@
 name: Check Node package.json Version Bump
-on:
-  workflow_call:
-    inputs:
-      should-bump-version:
-        description: list of branches that require version bump
-        required: false
-        default: "master"
-        type: string
 jobs:
   check-version-bump:
     runs-on: ubuntu-latest
-    if: contains(inputs.should-bump-version, github.base_ref)
 
     steps:
-      - name: echo stuff
-        run: |
-          echo should bump version ${{ inputs.should-bump-version }}
-          echo baseref ${{ github.base_ref }}
-          echo ${{contains(inputs.should-bump-version, github.base_ref)}}
-
       - name: Checkout current code
         uses: actions/checkout@v4
 

--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -1,9 +1,24 @@
 name: Check Node package.json Version Bump
+on:
+  workflow_call:
+    inputs:
+      should-bump-version:
+        description: list of branches that require version bump
+        required: false
+        default: "master"
+        type: string
 jobs:
   check-version-bump:
     runs-on: ubuntu-latest
+    if: contains(inputs.should-bump-version, github.base_ref)
 
     steps:
+      - name: echo stuff
+        run: |
+          echo should bump version ${{ inputs.should-bump-version }}
+          echo baseref ${{ github.base_ref }}
+          echo ${{contains(inputs.should-bump-version, github.base_ref)}}
+
       - name: Checkout current code
         uses: actions/checkout@v4
 

--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -6,7 +6,6 @@ on:
         description: list of branches that require version bump
         required: false
         type: string
-        default: "master"
 jobs:
   check-version-bump:
     runs-on: ubuntu-latest
@@ -18,12 +17,6 @@ jobs:
           echo should bump version ${{ inputs.should-bump-version }}
           echo baseref ${{ github.base_ref }}
           echo ${{contains(inputs.should-bump-version, github.base_ref)}}
-
-      - name: echo stuff
-        run: |
-          echo should bump version ${ inputs.should-bump-version }
-          echo baseref ${ github.base_ref }
-          echo ${contains(inputs.should-bump-version, github.base_ref)}
 
       - name: Checkout current code
         uses: actions/checkout@v4

--- a/.github/workflows/check-node-version-bump.yml
+++ b/.github/workflows/check-node-version-bump.yml
@@ -25,6 +25,10 @@ jobs:
           current_version="${{ steps.current.outputs.version }}"
           base_version="${{ steps.base.outputs.version }}"
 
+          echo current version: "$current_version"
+          echo base version: "$base_version"
+          echo base_ref "$github.base_ref"
+
           if [[ "$(printf '%s\n' "$current_version" "$base_version" | sort -V | tail -n 1)" == "$base_version" ]]; then
             echo "package.json version is not greater than the base branch. Please bump the version."
             exit 1

--- a/.github/workflows/frontend-build-and-publish-apps.yml
+++ b/.github/workflows/frontend-build-and-publish-apps.yml
@@ -35,6 +35,7 @@ on:
       should-bump-version:
         description: list of branches that require version bump
         required: false
+        default: "master"
         type: string
 
       publish:

--- a/.github/workflows/frontend-build-and-publish-apps.yml
+++ b/.github/workflows/frontend-build-and-publish-apps.yml
@@ -32,11 +32,6 @@ on:
         required: false
         type: string
         default: "6.0.x"
-      should-bump-version:
-        description: list of branches that require version bump
-        required: false
-        default: "master"
-        type: string
 
       publish:
         description: Set to true to publish artifacts to docker repository
@@ -67,11 +62,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-version-bump:
-    uses: ./.github/workflows/check-node-version-bump.yml
-    with:
-      should-bump-version: ${{ inputs.should-bump-version }}
-
   build:
     name: Build and publish
     runs-on: ubuntu-latest


### PR DESCRIPTION
When I initially developed the workflow, it was running on "pull_request" and on "push". Now the build-and-publish workflow is only running on "push" on all branches, which means I don't have the github.base_ref available anymore. WIth it being an empty string, all my if checks and the base version checkout couldn't work anymore :) 

For the check-version to make sense and to have all the info it needs, it has to run on "pull_request". But actually this version is much better in terms of isolating scopes and efficiency since I don't need the "if contains(...)" anymore. 