### PR TITLE
fix(downmerge): merge to the current release branch

### DIFF
--- a/.github/workflows/downmerge-releases.yml
+++ b/.github/workflows/downmerge-releases.yml
@@ -23,17 +23,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.github-token }}
 
-      - name: Find Opened Pull Request
-        id: find-pull-request
-        run: |
-          PULL_REQUEST_NUMBER=$(gh search prs $COMMIT_SHA --state=open --json number -L 1 -q ".[].number")
-          echo "number=${PULL_REQUEST_NUMBER}" >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
-          COMMIT_SHA: ${{ github.sha }}
-
       - name: Downmerge
-        if: ${{ steps.find-pull-request.outputs.number == '' }}
         id: downmerge
         run: |
           git fetch

--- a/.github/workflows/downmerge-releases.yml
+++ b/.github/workflows/downmerge-releases.yml
@@ -56,16 +56,23 @@ jobs:
             MAJOR_MINOR_BRANCH_VERSION=$(echo $BRANCH_VERSION | cut -d'.' -f1,2)
             PATCH_BRANCH_VERSION=$(echo $BRANCH_VERSION | cut -d'.' -f3,4)
             MAJOR_MINOR_PACKAGE_VERSION=$(echo $BASE_PACKAGE_VERSION | cut -d'.' -f1,2)
+            IS_CURRENT_RELEASE_BRANCH=$(if [[ "$PATCH_BRANCH_VERSION" == "x" && "$MAJOR_MINOR_BRANCH_VERSION" == "$MAJOR_MINOR_PACKAGE_VERSION" ]]; then echo "true"; else echo "false"; fi)
             branch="${branch#origin/}"
             if [ "$branch" != "$CURRENT_BRANCH" ]; then
-              if [[ $branch == "develop" || $MAJOR_MINOR_BRANCH_VERSION > $MAJOR_MINOR_PACKAGE_VERSION || ("$PATCH_BRANCH_VERSION" == "x" && "$MAJOR_MINOR_BRANCH_VERSION" == "$MAJOR_MINOR_PACKAGE_VERSION") ]]; then
+              if [[ $branch == "develop" || $MAJOR_MINOR_BRANCH_VERSION > $MAJOR_MINOR_PACKAGE_VERSION || "$IS_CURRENT_RELEASE_BRANCH" == true ]]; then
                 echo "::notice ::Downmerging branch: $branch from: $CURRENT_BRANCH"
 
                 git checkout $branch
 
                 # Merge changes from the remote branch into branch
-                if git merge --commit --no-ff --no-edit ${CURRENT_BRANCH}; then
+                if git merge --no-commit --no-ff --no-edit ${CURRENT_BRANCH}; then
+                if [[ "$IS_CURRENT_RELEASE_BRANCH" == false && (-z "$(git status --porcelain)") ]]; then
+                  echo "::notice ::Nothing to commit for branch: $branch"
+                fi  
+                else
+                  git commit --no-edit
                   git push origin $branch
+                fi
                 else
                   CONFLICTS="$(git diff --name-only --diff-filter=U)"
 

--- a/.github/workflows/downmerge-releases.yml
+++ b/.github/workflows/downmerge-releases.yml
@@ -64,32 +64,27 @@ jobs:
                 git checkout $branch
 
                 # Merge changes from the remote branch into branch
-                if git merge --no-commit --no-ff --no-edit ${CURRENT_BRANCH}; then
-                  if [ -z "$(git status --porcelain)" ]; then
-                    echo "::notice ::Nothing to commit for branch: $branch"
-                  else
-                    git commit --no-edit
+                if git merge --commit --no-ff --no-edit ${CURRENT_BRANCH}; then
+                  git push origin $branch
+                else
+                  CONFLICTS="$(git diff --name-only --diff-filter=U)"
+
+                  for file in $CONFLICTS; do
+                    echo "::notice ::Conflicts: $CONFLICTS"
+                    if [ "$file" == "package.json" ] || [ "$file" == "package-lock.json" ]; then
+                      echo "::notice ::Auto-resolving $file version conflicts by choosing the HEAD version."
+                      git checkout --ours $file
+                      git add $file
+                      MANUAL_MERGE=true
+                    else
+                      echo "::warning ::Failed to downmerge to branch: $branch. Merge error."
+                      exit 1
+                    fi
+                  done
+                  if [ "$MANUAL_MERGE" = true ]; then
+                    git commit -m "chore(*): auto-resolve version conflicts"
                     git push origin $branch
                   fi
-                else
-                    CONFLICTS="$(git diff --name-only --diff-filter=U)"
-
-                    for file in $CONFLICTS; do
-                      echo "::notice ::Conflicts: $CONFLICTS"
-                      if [ "$file" == "package.json" ] || [ "$file" == "package-lock.json" ]; then
-                          echo "::notice ::Auto-resolving $file version conflicts by choosing the HEAD version."
-                          git checkout --ours $file
-                          git add $file
-                          MANUAL_MERGE=true
-                      else
-                        echo "::warning ::Failed to downmerge to branch: $branch. Merge error."
-                        exit 1
-                      fi
-                    done
-                    if [ "$MANUAL_MERGE" = true ]; then
-                      git commit -m "chore(*): auto-resolve version conflicts"
-                      git push origin $branch
-                    fi
                 fi
               fi
             fi

--- a/.github/workflows/downmerge-releases.yml
+++ b/.github/workflows/downmerge-releases.yml
@@ -23,7 +23,17 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.github-token }}
 
+      - name: Find Opened Pull Request
+        id: find-pull-request
+        run: |
+          PULL_REQUEST_NUMBER=$(gh search prs $COMMIT_SHA --state=open --json number -L 1 -q ".[].number")
+          echo "number=${PULL_REQUEST_NUMBER}" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}
+          COMMIT_SHA: ${{ github.sha }}
+
       - name: Downmerge
+        if: ${{ steps.find-pull-request.outputs.number == '' }}
         id: downmerge
         run: |
           git fetch
@@ -44,41 +54,43 @@ jobs:
           for branch in $(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/release/*' "refs/remotes/origin/${{ inputs.base-branch }}"); do
             BRANCH_VERSION=$(echo $branch | cut -d'/' -f3)
             MAJOR_MINOR_BRANCH_VERSION=$(echo $BRANCH_VERSION | cut -d'.' -f1,2)
+            PATCH_BRANCH_VERSION=$(echo $BRANCH_VERSION | cut -d'.' -f3,4)
             MAJOR_MINOR_PACKAGE_VERSION=$(echo $BASE_PACKAGE_VERSION | cut -d'.' -f1,2)
             branch="${branch#origin/}"
+            if [ "$branch" != "$CURRENT_BRANCH" ]; then
+              if [[ $branch == "develop" || $MAJOR_MINOR_BRANCH_VERSION > $MAJOR_MINOR_PACKAGE_VERSION || ("$PATCH_BRANCH_VERSION" == "x" && "$MAJOR_MINOR_BRANCH_VERSION" == "$MAJOR_MINOR_PACKAGE_VERSION") ]]; then
+                echo "::notice ::Downmerging branch: $branch from: $CURRENT_BRANCH"
 
-            if [[ $branch == "develop" || $MAJOR_MINOR_BRANCH_VERSION > $MAJOR_MINOR_PACKAGE_VERSION ]]; then
-              echo "::notice ::Downmerging branch: $branch from: $CURRENT_BRANCH"
+                git checkout $branch
 
-              git checkout $branch
-
-              # Merge changes from the remote branch into branch
-              if git merge --no-commit --no-ff --no-edit ${CURRENT_BRANCH}; then
-                if [ -z "$(git status --porcelain)" ]; then
-                  echo "::notice ::Nothing to commit for branch: $branch"
-                else
-                  git commit --no-edit
-                  git push origin $branch
-                fi
-              else
-                  CONFLICTS="$(git diff --name-only --diff-filter=U)"
-
-                  for file in $CONFLICTS; do
-                    echo "::notice ::Conflicts: $CONFLICTS"
-                    if [ "$file" == "package.json" ] || [ "$file" == "package-lock.json" ]; then
-                        echo "::notice ::Auto-resolving $file version conflicts by choosing the HEAD version."
-                        git checkout --ours $file
-                        git add $file
-                        MANUAL_MERGE=true
-                    else
-                      echo "::warning ::Failed to downmerge to branch: $branch. Merge error."
-                      exit 1
-                    fi
-                  done
-                  if [ "$MANUAL_MERGE" = true ]; then
-                    git commit -m "chore(*): auto-resolve version conflicts"
+                # Merge changes from the remote branch into branch
+                if git merge --no-commit --no-ff --no-edit ${CURRENT_BRANCH}; then
+                  if [ -z "$(git status --porcelain)" ]; then
+                    echo "::notice ::Nothing to commit for branch: $branch"
+                  else
+                    git commit --no-edit
                     git push origin $branch
                   fi
+                else
+                    CONFLICTS="$(git diff --name-only --diff-filter=U)"
+
+                    for file in $CONFLICTS; do
+                      echo "::notice ::Conflicts: $CONFLICTS"
+                      if [ "$file" == "package.json" ] || [ "$file" == "package-lock.json" ]; then
+                          echo "::notice ::Auto-resolving $file version conflicts by choosing the HEAD version."
+                          git checkout --ours $file
+                          git add $file
+                          MANUAL_MERGE=true
+                      else
+                        echo "::warning ::Failed to downmerge to branch: $branch. Merge error."
+                        exit 1
+                      fi
+                    done
+                    if [ "$MANUAL_MERGE" = true ]; then
+                      git commit -m "chore(*): auto-resolve version conflicts"
+                      git push origin $branch
+                    fi
+                fi
               fi
             fi
             echo "manual-merge=${MANUAL_MERGE}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/downmerge-releases.yml
+++ b/.github/workflows/downmerge-releases.yml
@@ -56,19 +56,18 @@ jobs:
             MAJOR_MINOR_BRANCH_VERSION=$(echo $BRANCH_VERSION | cut -d'.' -f1,2)
             PATCH_BRANCH_VERSION=$(echo $BRANCH_VERSION | cut -d'.' -f3,4)
             MAJOR_MINOR_PACKAGE_VERSION=$(echo $BASE_PACKAGE_VERSION | cut -d'.' -f1,2)
-            IS_CURRENT_RELEASE_BRANCH=$(if [[ "$PATCH_BRANCH_VERSION" == "x" && "$MAJOR_MINOR_BRANCH_VERSION" == "$MAJOR_MINOR_PACKAGE_VERSION" ]]; then echo "true"; else echo "false"; fi)
+            IS_CURRENT_RELEASE_BRANCH=$(if [[ $PATCH_BRANCH_VERSION == "x" && $MAJOR_MINOR_BRANCH_VERSION == $MAJOR_MINOR_PACKAGE_VERSION ]]; then echo "true"; else echo "false"; fi)
             branch="${branch#origin/}"
             if [ "$branch" != "$CURRENT_BRANCH" ]; then
-              if [[ $branch == "develop" || $MAJOR_MINOR_BRANCH_VERSION > $MAJOR_MINOR_PACKAGE_VERSION || "$IS_CURRENT_RELEASE_BRANCH" == true ]]; then
+              if [[ $branch == "develop" || $MAJOR_MINOR_BRANCH_VERSION > $MAJOR_MINOR_PACKAGE_VERSION || $IS_CURRENT_RELEASE_BRANCH == true ]]; then
                 echo "::notice ::Downmerging branch: $branch from: $CURRENT_BRANCH"
 
                 git checkout $branch
 
                 # Merge changes from the remote branch into branch
                 if git merge --no-commit --no-ff --no-edit ${CURRENT_BRANCH}; then
-                if [[ "$IS_CURRENT_RELEASE_BRANCH" == false && (-z "$(git status --porcelain)") ]]; then
+                if [[ $IS_CURRENT_RELEASE_BRANCH == false && (-z "$(git status --porcelain)") ]]; then
                   echo "::notice ::Nothing to commit for branch: $branch"
-                fi  
                 else
                   git commit --no-edit
                   git push origin $branch


### PR DESCRIPTION
We found an issue when we merge a release branch to master, it doesn't do downmerge because there is nothing to commit, but there is an ignored merge commit. When we open a new pr from the same release branch it shows that the release branch is outdated and we have to do downmerges manually: example https://github.com/River-iGaming/azurolongo.jackpotbob/pull/518

Merge to master - Downmerge to release branches and develop
  * develop
  * same `release/1.2.x` version
  * higher `release/1.3.x` version
<img width="932" alt="Screenshot 2023-12-11 at 11 50 02" src="https://github.com/River-iGaming/workflows/assets/10487250/b49480ae-66f1-4d3a-9a07-6d36f032f460">

Downmerge to develop if nothing to commit
<img width="647" alt="Screenshot 2023-12-11 at 12 06 01" src="https://github.com/River-iGaming/workflows/assets/10487250/fa06019f-8521-4786-adf3-fcf211683342">


