### PR TITLE
feat(dotnet libs): remove build FileVersion due to warns

### DIFF
--- a/.github/workflows/dotnet-libs.yml
+++ b/.github/workflows/dotnet-libs.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Build
         env:
           APP_VERSION: ${{ steps.version.outputs.app-version }}
-        run: dotnet build -p:PackageVersion=$APP_VERSION -p:AssemblyVersion=${{ env.PACKAGE_VERSION }} -p:FileVersion=$APP_VERSION $SOLUTION -c Release
+        run: dotnet build -p:PackageVersion=$APP_VERSION -p:AssemblyVersion=${{ env.PACKAGE_VERSION }} $SOLUTION -c Release
 
       - name: Test
         run: npm test


### PR DESCRIPTION
Will revert this as its output the following warnings:

> The specified version string '15.0.0-feature-rtmw-3579-upgrade-dotnet8-and-orleans8-8933' does not conform to the recommended format - major.minor.build.revision

Instead will make use the `PackageVersion` provided