### PR TITLE
Added version limits to Odin.Messaging.SerDes

### DIFF
--- a/.github/workflows/java-publish-nugets.yml
+++ b/.github/workflows/java-publish-nugets.yml
@@ -70,7 +70,7 @@ jobs:
           rm out/$PACKAGE/Class1.cs
           # Generate .NET classes from Avro Schema
           avromagic --schema-path ${{ inputs.avro-path }} --output-dir ./out/$PACKAGE
-          dotnet add ./out/$PACKAGE package Odin.Messaging.SerDes
+          dotnet add ./out/$PACKAGE package Odin.Messaging.SerDes -v "[15.110,666)" # A test version was labelled 666.0.0 which will always be the upper bound when restoring the package. Needs to be excluded.
           dotnet pack -c Release -p:PackageVersion=$NUGET_VERSION ./out/$PACKAGE -o ./nupkg/
       - name: Push Nuget package to Nexus
         run: |


### PR DESCRIPTION
Version 666.0.0 was mistakenly published and will always get incorrectly included even if "never" versions exist.