### PR TITLE
Feature/multi build and package

### DIFF
--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -112,7 +112,9 @@ jobs:
         name: Uploading artifacts
         with:
           name: projects
-          path: "**/target/*-exec.jar"
+          path: |
+            dockerfile
+            **/target/*-exec.jar
         
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -1,11 +1,10 @@
 on:
   workflow_call:
-    # inputs:
-    #   exec-project:
-    #     description: The main executable project
-    #     required: false
-    #     type: string
-    #     default: '.'
+    inputs:
+      projects:
+        description: all project to build docker stuff u hekk
+        required: true
+        type: string
 
 jobs:
   build:
@@ -28,9 +27,12 @@ jobs:
   package:
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      matrix:
+        project: ${{ fromJSON(github.event.inputs.projects)}}
     steps: 
       - uses: actions/download-artifact@v4
         with:
           name: projects
       - name: Display structure of downloaded files
-        run: ls -R
+        run: ls -R  ${{ matrix.project }}

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -42,6 +42,7 @@ on:
         value: ${{ jobs.build.outputs.final-version }}
 jobs:
   build:
+    name: Build projects
     runs-on: ubuntu-latest
     outputs:
       project-version: ${{ steps.versioning.outputs.project-version }}
@@ -113,10 +114,11 @@ jobs:
         with:
           name: projects
           path: |
-            dockerfile
+            Dockerfile
             **/target/*-exec.jar
         
   package:
+    name: Publish docker images
     runs-on: ubuntu-latest
     needs: build
     strategy:

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -160,8 +160,8 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ needs.build.outputs.final-version }}
-          EXEC_PROJECT: ${{ matrix.project }}
-          ECR_REPOSITORY: wallet-poc-${{ matrix.project }}
+          EXEC_PROJECT: ${{ matrix.project.path }}
+          ECR_REPOSITORY: ${{ matrix.project.ecr-repository }}
         run: |
           REPO=$(git config --get remote.origin.url)
           DATE=$(date --utc +%FT%TZ)

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       projects:
-        description: The main executable project
+        description: JSON array of project and ecr-repository
         required: true
         type: string
       java-version:
@@ -118,7 +118,7 @@ jobs:
             **/target/*-exec.jar
         
   package:
-    name: Publish docker images
+    name: Publish
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -128,20 +128,15 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: projects
-      - run: ls -R
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
           aws-region: eu-west-1
-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-
-      ########
-      # beginning of common functionality to build multi-platform docker images
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
@@ -150,15 +145,6 @@ jobs:
       - name: Setup Docker buildx
         id: buildx-setup
         uses: docker/setup-buildx-action@v2
-
-      - name: Inspect builder
-        shell: bash
-        run: |
-          echo "Name:      ${{ steps.buildx-setup.outputs.name }}"
-          echo "Endpoint:  ${{ steps.buildx-setup.outputs.endpoint }}"
-          echo "Status:    ${{ steps.buildx-setup.outputs.status }}"
-          echo "Flags:     ${{ steps.buildx-setup.outputs.flags }}"
-          echo "Platforms: ${{ steps.buildx-setup.outputs.platforms }}"
 
       - name: Build, tag, and push image to Amazon ECR
         env:
@@ -179,10 +165,7 @@ jobs:
           --platform ${{ inputs.docker-platforms }} \
           --progress plain --push .
 
-          echo "::notice::Pushed image $ECR_REPOSITORY:$IMAGE_TAG to $ECR_REGISTRY"
-
-      # end of common multi-platform build functionality
-      #########
+          echo "::notice::Pushed image \`$ECR_REPOSITORY\`: \`$IMAGE_TAG\`"
 
       - name: Logout of Amazon ECR
         if: always()

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -1,0 +1,36 @@
+on:
+  workflow_call:
+    # inputs:
+    #   exec-project:
+    #     description: The main executable project
+    #     required: false
+    #     type: string
+    #     default: '.'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: make fake files
+        run: |
+          mkdir {p1,p2,p3}/target
+          a >> p1/target/project-exec.jar
+          b >> p2/target/project-exec.jar
+          c >> p3/target/project-exec.jar
+      - uses: actions/upload-artifact@v4
+        id: artifact-upload-step
+        with:
+          name: projects
+          path: "**/target/*-exec.jar"
+      - name: Output artifact ID
+        run:  echo 'Artifact ID is ${{ steps.artifact-upload-step.outputs.artifact-id }}'
+        
+  package:
+    runs-on: ubuntu-latest
+    needs: build
+    steps: 
+      - uses: actions/download-artifact@v4
+        with:
+          name: projects
+      - name: Display structure of downloaded files
+        run: ls -R

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -112,7 +112,12 @@ jobs:
           echo "::notice::Setting ${{ inputs.ecr-repository }} version to: $RELEASE_TAG"
           echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
           echo "final-version=$RELEASE_TAG" >> $GITHUB_OUTPUT
-      
+      - uses: actions/upload-artifact@v4
+        id: artifact-upload-step
+        name: Uploading artifacts
+        with:
+          name: projects
+          path: "**/target/*-exec.jar"
         
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -2,27 +2,117 @@ on:
   workflow_call:
     inputs:
       projects:
-        description: all project to build docker stuff u hekk
+        description: The main executable project
         required: true
         type: string
-
+      ecr-repository:
+        description: Name of ECR repository for project
+        required: true
+        type: string
+      java-version:
+        description: JDK version (defaults to 8)
+        required: false
+        type: string
+        default: '8'
+      maven-command:
+        description: The maven command to execute for main build
+        required: false
+        type: string
+        default: 'mvn -B deploy -ntp'
+      maven-extra-args:
+        description: Additional maven arguments to be appended to command
+        required: false
+        type: string
+      docker-platforms:
+        description: "Comma seperated list of platforms to use when building the docker image"
+        required: false
+        type: string
+        default: "linux/amd64,linux/arm64"
+    secrets:
+      nexus-username:
+        required: true
+      nexus-password:
+        required: true
+      aws-access-key-id:
+        required: true
+      aws-secret-access-key:
+        required: true
+      sonar-token:
+        required: false
+    outputs:
+      project-version:
+        value: ${{ jobs.build.outputs.project-version }}
+      image-version:
+        value: ${{ jobs.build.outputs.final-version }}
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      project-version: ${{ steps.versioning.outputs.project-version }}
+      final-version: ${{ steps.versioning.outputs.final-version }}
     steps:
-      - name: make fake files
-        run: |
-          mkdir -p {p1,p2,p3}/target
-          echo a >> p1/target/project-exec.jar
-          echo b >> p2/target/project-exec.jar
-          echo c >> p3/target/project-exec.jar
-      - uses: actions/upload-artifact@v4
-        id: artifact-upload-step
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4.2.1 
         with:
-          name: projects
-          path: "**/target/*-exec.jar"
-      - name: Output artifact ID
-        run:  echo 'Artifact ID is ${{ steps.artifact-upload-step.outputs.artifact-id }}'
+          distribution: 'temurin'
+          java-version: ${{ inputs.java-version }}
+
+      - name: Setting up maven settings.xml
+        uses: whelk-io/maven-settings-xml-action@v22
+        with:
+          servers: '[{ "id": "river-nexus", "username": "${{ secrets.nexus-username }}", "password": "${{ secrets.nexus-password }}" },{ "id": "platform-snapshots", "username": "${{ secrets.nexus-username }}", "password": "${{ secrets.nexus-password }}" },{ "id": "platform-releases", "username": "${{ secrets.nexus-username }}", "password": "${{ secrets.nexus-password }}" }]'
+          mirrors: '[{ "id": "river-nexus", "mirrorOf": "*", "url": "https://nexus.riverigaming.tech/repository/maven-public/" }]'
+          repositories: '[{ "id": "river-nexus", "url": "https://nexus.riverigaming.tech/repository/platform-releases" }]'
+
+      - name: Cache
+        if: ${{ github.run_attempt == 1 }}
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/com/river
+            !~/.m2/repository/com/bejig
+          key: river-cache
+          restore-keys: river-cache
+
+      - name: Build with Maven
+        run: ${{ inputs.maven-command }} ${{ inputs.maven-extra-args }}
+
+      - name: Run SonarQube if enabled
+        if: env.SONAR_TOKEN
+        run: mvn -ntp sonar:sonar -Dsonar.login=$SONAR_TOKEN
+        env:
+          SONAR_TOKEN: ${{ secrets.sonar-token }}
+
+      - name: Get release version
+        id: versioning
+        run: |
+          PROJECT_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
+          BRANCH=${{ github.ref_name }}
+          if [ ${{github.run_attempt}} -eq 1 ]
+          then
+            BUILD_NUMBER=${{ github.run_number}}
+          else
+            BUILD_NUMBER=${{ github.run_number}}-${{github.run_attempt}}
+          fi
+          case $BRANCH in
+            master)
+              VERSION=$BRANCH-$PROJECT_VERSION
+              ;;
+            develop)
+              VERSION=$(echo $BRANCH-$PROJECT_VERSION | sed "s/-SNAPSHOT/-$BUILD_NUMBER/")
+              ;;
+            *)
+              VERSION=$BRANCH-$BUILD_NUMBER
+              ;;
+          esac
+          RELEASE_TAG=$( echo $VERSION | sed "s/[^[:alnum:]#._-]/-/g" )
+          echo "::notice::Setting ${{ inputs.ecr-repository }} version to: $RELEASE_TAG"
+          echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
+          echo "final-version=$RELEASE_TAG" >> $GITHUB_OUTPUT
+      
         
   package:
     runs-on: ubuntu-latest
@@ -34,5 +124,64 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: projects
-      - name: Display structure of downloaded files
-        run: ls -R  ${{ matrix.project }}
+      
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.aws-access-key-id }}
+          aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
+          aws-region: eu-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      ########
+      # beginning of common functionality to build multi-platform docker images
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Setup Docker buildx
+        id: buildx-setup
+        uses: docker/setup-buildx-action@v2
+
+      - name: Inspect builder
+        shell: bash
+        run: |
+          echo "Name:      ${{ steps.buildx-setup.outputs.name }}"
+          echo "Endpoint:  ${{ steps.buildx-setup.outputs.endpoint }}"
+          echo "Status:    ${{ steps.buildx-setup.outputs.status }}"
+          echo "Flags:     ${{ steps.buildx-setup.outputs.flags }}"
+          echo "Platforms: ${{ steps.buildx-setup.outputs.platforms }}"
+
+      - name: Build, tag, and push image to Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ needs.build.outputs.final-version }}
+          EXEC_PROJECT: ${{ matrix.project }}
+          ECR_REPOSITORY: wallet-poc-${{ matrix.project }}
+        run: |
+          REPO=$(git config --get remote.origin.url)
+          DATE=$(date --utc +%FT%TZ)
+          docker buildx build \
+          --build-arg JAR_FILE=$EXEC_PROJECT/target/*-exec.jar \
+          --build-arg GIT_HASH=${{ github.sha }} \
+          --build-arg DATE="$DATE" \
+          --build-arg GIT_REPO=$REPO \
+          --build-arg GIT_REF=${{ github.ref }} \
+          --build-arg VERSION=${{ env.IMAGE_TAG }} \
+          -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+          --platform ${{ inputs.docker-platforms }} \
+          --progress plain --push .
+
+          echo "::notice::Pushed image $ECR_REPOSITORY:$IMAGE_TAG to $ECR_REGISTRY"
+
+      # end of common multi-platform build functionality
+      #########
+
+      - name: Logout of Amazon ECR
+        if: always()
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}
+

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: make fake files
         run: |
-          mkdir {p1,p2,p3}/target
+          mkdir -p {p1,p2,p3}/target
           a >> p1/target/project-exec.jar
           b >> p2/target/project-exec.jar
           c >> p3/target/project-exec.jar

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -165,7 +165,7 @@ jobs:
           --platform ${{ inputs.docker-platforms }} \
           --progress plain --push .
 
-          echo "::notice::Pushed image \`$ECR_REPOSITORY\`: \`$IMAGE_TAG\`"
+          echo "::notice::Pushed image $ECR_REPOSITORY:$IMAGE_TAG"
 
       - name: Logout of Amazon ECR
         if: always()

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -29,7 +29,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        project: ${{ fromJSON(github.event.inputs.projects)}}
+        project: ${{ fromJSON(inputs.projects)}}
     steps: 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -5,10 +5,6 @@ on:
         description: The main executable project
         required: true
         type: string
-      ecr-repository:
-        description: Name of ECR repository for project
-        required: true
-        type: string
       java-version:
         description: JDK version (defaults to 8)
         required: false
@@ -109,7 +105,6 @@ jobs:
               ;;
           esac
           RELEASE_TAG=$( echo $VERSION | sed "s/[^[:alnum:]#._-]/-/g" )
-          echo "::notice::Setting ${{ inputs.ecr-repository }} version to: $RELEASE_TAG"
           echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
           echo "final-version=$RELEASE_TAG" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -14,9 +14,9 @@ jobs:
       - name: make fake files
         run: |
           mkdir -p {p1,p2,p3}/target
-          a >> p1/target/project-exec.jar
-          b >> p2/target/project-exec.jar
-          c >> p3/target/project-exec.jar
+          echo a >> p1/target/project-exec.jar
+          echo b >> p2/target/project-exec.jar
+          echo c >> p3/target/project-exec.jar
       - uses: actions/upload-artifact@v4
         id: artifact-upload-step
         with:

--- a/.github/workflows/java-build-and-publish-multi.yaml
+++ b/.github/workflows/java-build-and-publish-multi.yaml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: projects
-      
+      - run: ls -R
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -167,13 +167,12 @@ jobs:
           EXEC_PROJECT: ${{ matrix.project.path }}
           ECR_REPOSITORY: ${{ matrix.project.ecr-repository }}
         run: |
-          REPO=$(git config --get remote.origin.url)
           DATE=$(date --utc +%FT%TZ)
           docker buildx build \
           --build-arg JAR_FILE=$EXEC_PROJECT/target/*-exec.jar \
           --build-arg GIT_HASH=${{ github.sha }} \
           --build-arg DATE="$DATE" \
-          --build-arg GIT_REPO=$REPO \
+          --build-arg GIT_REPO=$GITHUB_REPOSITORY \
           --build-arg GIT_REF=${{ github.ref }} \
           --build-arg VERSION=${{ env.IMAGE_TAG }} \
           -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \


### PR DESCRIPTION
This pull request introduces a new reusable GitHub Actions workflow for building and publishing Java projects with Maven and Docker. The workflow supports multiple projects, integrates with SonarQube for code quality analysis, and automates Docker image creation and publishing to Amazon ECR.

### Workflow Enhancements:
* Added a reusable workflow (`.github/workflows/java-build-and-publish-multi.yaml`) that allows for building Java projects using Maven, with configurable inputs such as `java-version`, `maven-command`, and additional Maven arguments.
* Integrated caching for Maven dependencies to optimize build performance, with exclusions for specific repositories.
* Configured SonarQube analysis as an optional step, triggered if a `sonar-token` secret is provided.

### Docker and ECR Automation:
* Automated Docker image building and publishing to Amazon ECR, with support for multi-platform builds using Docker Buildx and QEMU.
* Configured dynamic versioning for Docker images based on the branch name and build metadata.

### Security and Credentials Management:
* Utilized GitHub Actions secrets for securely managing credentials, including Nexus repository credentials, AWS access keys, and SonarQube tokens.